### PR TITLE
gcc 9 compilation error: do not jump away from initializing variables

### DIFF
--- a/src/diann.cpp
+++ b/src/diann.cpp
@@ -2550,6 +2550,7 @@ struct Feature {
 			if (pos == frm.end()) continue;
 			while (pos->mz < high) {
 				if (open && iter == 1 && pos->charge != 1) goto finish;
+				{
 				auto &pr = precursors[pos->pr];
 				if ((open || (pr.first > min && pr.first < max)) && pr.second == charge) {
 					if (size <= pos->pr) size = ((pos->pr * 5) / 4) + 1, temp.resize(size);
@@ -2579,6 +2580,7 @@ struct Feature {
 						match[j].score = p.score;
 						if (open) match[j].fr = fr;
 					}
+				}
 				}
 			finish:
 				pos++;
@@ -5390,13 +5392,14 @@ public:
 				else reference[i] = -INF;
 			}
 
+			int ni = indices.size();
+
 			int tot_pr = 0; for (i = 0; i < prs_n; i++) if (prn[i]) tot_pr++;
 			if (tot_pr < 2) {
 				for (i = 0; i < n_s; i++) quantities[i] = reference[i];
 				goto save;
 			}
 
-			int ni = indices.size();
 			B.resize(ni); A.resize(ni, ni);
 			for (i = 0; i < ni; i++) {
 				B(i) = 0.0;


### PR DESCRIPTION
gcc version 9.3.0 treats these as errors

from C++ standard:
It is possible to transfer into a block, but not in a way that bypasses
declarations with initialization. A program that jumps from a point
where a local variable with automatic storage duration is not in scope
to a point where it is in scope is ill-formed unless the variable has
POD type (3.9) and is declared without an initializer.

../src/diann.cpp: In member function ‘void Feature::find(bool, std::vector<Mass>&, std::vector<Mass>&, std::vector<std::pair<float, int> >&, double, double, std::vector<Match>&)’:
../src/diann.cpp:2583:4: error: jump to label ‘finish’
 2583 |    finish:
      |    ^~~~~~
../src/diann.cpp:2552:53: note:   from here
 2552 |     if (open && iter == 1 && pos->charge != 1) goto finish;
      |                                                     ^~~~~~
../src/diann.cpp:2553:11: note:   crosses initialization of ‘std::pair<float, int>& pr’
 2553 |     auto &pr = precursors[pos->pr];
      |           ^~

../src/diann.cpp: In member function ‘void Library::max_lfq_quant(std::vector<PG>*, std::vector<Lock>*, double, bool)’:
../src/diann.cpp:5443:4: error: jump to label ‘save’
 5443 |    save:
      |    ^~~~
../src/diann.cpp:5396:10: note:   from here
 5396 |     goto save;
      |          ^~~~
../src/diann.cpp:5399:8: note:   crosses initialization of ‘int ni’
 5399 |    int ni = indices.size();